### PR TITLE
Support for annotating a publication commit with additional tags (branches, actually)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.3-beta
+Support extra GIT tags (actually branches, to be better movable) to set for the
+publication commit. These names can then be used as alternate version
+reference(s) on consumption side.
+
 ## 0.2.2-beta
 Support type definitions (d.ts files) in published package
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,13 @@ publish(packageDir, gitRemoteUrl [, options] )
     String value to use for the tag name. The version used to generate the
     default tag name will be read after any transforms are run, if provided.
 
+* **extraBranchNames** (string[])
+
+    An array of custom GIT branch names used to annotate the commit of the
+    current publication, in addition to `tagName`. These names are movable,
+    can be reused in later publications again and may serve as additional
+    version references by consumers.
+
 * **tagMessageText** (string)
 
     Default: the same value as `commitText` (custom, if provided, else the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-git-publish",
-  "version": "0.2.2-beta",
+  "version": "0.2.3-beta",
   "description": "Dev tool to publish an NPM package to a remote Git repository, instead of a registry or CDN of tarballs",
   "main": "lib/publish",
   "typings": "lib/publish",


### PR DESCRIPTION
Added support to annotate a publication commit with additional version tags (actually branch names) that can be re-used in new publications. These names can be used as further version references by component consumers.

This allows to e.g. move forward a V1.1 tag (set in addition to dedicated V1.1.x tags) and will allow a consumer to take a reference to the always latest (non-breaking) patch-level version within V1.1.