### PR TITLE
Fix: Using the `--force` option to push moved branches (version tags)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.4-beta
+Bug fix: Using the `--force` option to push a moved branch (version tag) to remote, as
+required under certain circumstances.
+
 ## 0.2.3-beta
 Support extra GIT tags (actually branches, to be better movable) to set for the
 publication commit. These names can then be used as alternate version

--- a/lib/publish.ts
+++ b/lib/publish.ts
@@ -203,7 +203,7 @@ function doPublish(packageDir: string, gitRemoteUrl: string, params: Params): Pr
     function pushDefaultBranch() {
         const extraBranchNames = (params.extraBranchNames || []).join(' ');
         execSync(
-            `git push --follow-tags origin HEAD ${extraBranchNames}`,
+            `git push --follow-tags --force origin HEAD ${extraBranchNames}`,
             { cwd: gitRepoDir, stdio: 'inherit' }
         );
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-git-publish",
-  "version": "0.2.3-beta",
+  "version": "0.2.4-beta",
   "description": "Dev tool to publish an NPM package to a remote Git repository, instead of a registry or CDN of tarballs",
   "main": "lib/publish",
   "typings": "lib/publish",


### PR DESCRIPTION
In *local* repo (re-)setting extra version tags (branch names) to current version requires the --force option on the 'git branch' command as the branch name might exist already.

In productive usage of the tool we encountered that certain *remote* repos in addition require the --force option on the 'git push' command for this purpose. This fix is adding this option.