### PR TITLE
npm-git-publish - Remote Code Execution (RCE) - Fix:

### DIFF
--- a/lib/publish.ts
+++ b/lib/publish.ts
@@ -2,6 +2,7 @@ import { execSync, exec as _exec } from 'child_process';
 import * as path from 'path';
 import * as pify from 'pify';
 import * as fs from 'fs';
+import * as isGitUrl from 'is-git-url';
 
 import mkdirp from './wrappers/mkdirp'
 import rimraf from './wrappers/rimraf';
@@ -58,6 +59,11 @@ export function publish(packageDir: string,
     tagMessageText?: string,
     tempDir?: string,
     packageInfo?: PackageInfo): Promise<boolean | Result> {
+
+    if (!isGitUrl(gitRemoteUrl)) {
+        console.log('\nERROR: The given Git Repo URL is not valid\n');
+        return;
+    }
 
     if (typeof options === 'string') {
         // using the deprecated overload

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "typings": "^0.6.5"
   },
   "dependencies": {
+    "is-git-url": "^1.0.0",
     "mkdirp": "^0.5.1",
     "pify": "^2.3.0",
     "read-pkg": "^1.1.0",


### PR DESCRIPTION
https://github.com/mufeedvh fixed the vulnerability associated with Remote Code Execution (RCE).
This fix is being submitted on behalf of https://github.com/mufeedvh - they have been awarded $25 for fixing the vulnerability through the huntr bug bounty program.
Think you could fix a vulnerability like this - get involved (https://huntr.dev).
Q | A
Version Affected | ALL
Bug Fix | YES
Further References | https://github.com/418sec/npm-git-publish/pull/1