### PR TITLE
RCE fix: replaced child_process execSync with spawn

### DIFF
--- a/lib/publish.ts
+++ b/lib/publish.ts
@@ -1,4 +1,4 @@
-import { execSync, exec as _exec } from 'child_process';
+import { execSync, exec as _exec, spawn } from 'child_process';
 import * as path from 'path';
 import * as pify from 'pify';
 import * as fs from 'fs';
@@ -148,7 +148,7 @@ function doPublish(packageDir: string, gitRemoteUrl: string, params: Params): Pr
 
     function cloneRemoteToTempRepo() {
         return initialCleanDone.then(() => {
-            execSync(`git clone --quiet --depth 1 ${gitRemoteUrl} "${gitRepoDir}"`, { stdio: 'inherit' });
+            spawn(`git`, ['clone', '--quiet', '--depth', '1', gitRemoteUrl, gitRepoDir], { stdio: 'inherit' });
         });
     }
 

--- a/lib/publish.ts
+++ b/lib/publish.ts
@@ -93,7 +93,6 @@ function run(cmd: string[], options?: Object) {
 function parseOut(proc: ChildProcess): Promise<string> {
   return new Promise((resolve, reject) => {
     let out = '';
-    console.log({proc})
     proc.stdout && proc.stdout.on('data', (data: string) => {
       out += data;
     });
@@ -153,7 +152,7 @@ function doPublish(packageDir: string, gitRemoteUrl: string, params: Params): Pr
 
     function packPackageIntoTarball() {
         return directoryReady
-            .then(() => run([`npm`, `pack`, `"${packageDir}"`], { cwd: packDir, stdio: 'inherit' }))
+            .then(() => run([`npm`, `pack`, `"${packageDir}"`], { cwd: packDir }))
             .then(() => {
                 // pack succeeded! Schedule a cleanup and return the full path
                 cleanupOperations.push(


### PR DESCRIPTION
### 📊 Metadata *

The npm-git-publish module is vulnerable against RCE due to user-supplied inputs being formatted and executed without proper validation

#### Bounty URL:  https://www.huntr.dev/bounties/1-npm-npm-git-publish/

### ⚙️ Description *

Mitigating the arbitrary code execution by changing the execution means rather than using more library code for sanitizing. 

### 💻 Technical Description *

Every call to "child_process.execSync" api is replaced by "child_process.spawn" apis. The `spawn`  method spawns a new process using the given command, with command-line arguments in args. If omitted, args defaults to an empty array. This mitigates the arbitrary code execution vulnerability.

### 🐛 Proof of Concept (PoC) *

Create the following PoC file:

`// poc.js`
`var git = require('npm-git-publish');`
`git.publish('.', 'http://gihub.com ;touch HACKED; #')`

Check there aren't files called HACKED
Execute the following commands in another terminal:

`npm i npm-git-publish # Install affected module`
`node poc.js #  Run the PoC`

Recheck the files: now HACKED has been created

### 🔥 Proof of Fix (PoF) *

Before: 

![rce-before](https://user-images.githubusercontent.com/64132745/100233664-0d2eeb80-2f50-11eb-8325-34a34db148d4.PNG)

After:

![rce-after](https://user-images.githubusercontent.com/64132745/100234129-a4943e80-2f50-11eb-86a2-39e95d2e534b.PNG)


### 👍 User Acceptance Testing (UAT)

![test](https://user-images.githubusercontent.com/64132745/100234194-bbd32c00-2f50-11eb-8e2e-b3177c482789.PNG)

