### PR TITLE
Fix #26 - Clean whole npm cache

### DIFF
--- a/lib/publish.ts
+++ b/lib/publish.ts
@@ -132,7 +132,7 @@ function doPublish(packageDir: string, gitRemoteUrl: string, params: Params): Pr
             .then(() => exec(`npm pack "${packageDir}"`, { cwd: packDir }))
             .then(() => {
                 // pack succeeded! Schedule a cleanup and return the full path
-                cleanupOperations.push(exec(`npm cache clean ${params.originalPackageInfo.name}@${params.originalPackageInfo.version}`));
+                cleanupOperations.push(exec(`npm cache clean --force`));
                 return path.join(packDir, computeTarballName());
             });
     }


### PR DESCRIPTION
`npm` dropped its support for cleaning individual cache items in 6.2.0;
manual says that you have to use `cacache` directly to do more granular
manipulations now. Since this couples us tightly to `npm`
implementation details, we should instead clear the whole cache.